### PR TITLE
DOCSUP-1110: document the extractAllGroups function

### DIFF
--- a/docs/en/sql-reference/functions/splitting-merging-functions.md
+++ b/docs/en/sql-reference/functions/splitting-merging-functions.md
@@ -113,7 +113,7 @@ SELECT alphaTokens('abca1abc')
 
 ## extractAllGroups(text, regexp) {#extractallgroups}
 
-Extracts from `text` all matching non-overlapping groups with regular expressions.
+Extracts all groups from non-overlapping substrings matched by a regular expression.
 
 **Syntax** 
 
@@ -123,14 +123,14 @@ extractAllGroups(text, regexp)
 
 **Parameters** 
 
--   `text` —  Const or non-const column with text to apply regular expression against. [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md).
--   `regexp` — Const column with regular expression. [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md).
+-   `text` — [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md).
+-   `regexp` — Regular expression. Constant. [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md).
 
 **Returned values**
 
--   If ClickHouse finds at least one matching group, returns `Array(Array(String))` column, clustered by group_id (1 to N, where N is number of capturing groups in `regexp`).
+-   If the function finds at least one matching group, it returns `Array(Array(String))` column, clustered by group_id (1 to N, where N is number of capturing groups in `regexp`).
 
--   If there is no matching group, returns empty array.
+-   If there is no matching group, returns an empty array.
 
 Type: [Array](../data-types/array.md).
 

--- a/docs/en/sql-reference/functions/splitting-merging-functions.md
+++ b/docs/en/sql-reference/functions/splitting-merging-functions.md
@@ -111,4 +111,43 @@ SELECT alphaTokens('abca1abc')
 └─────────────────────────┘
 ```
 
+## extractAllGroups(text, regexp) {#extractallgroups}
+
+Extracts from `text` all matching non-overlapping groups with regular expressions.
+
+**Syntax** 
+
+``` sql
+extractAllGroups(text, regexp) 
+```
+
+**Parameters** 
+
+-   `text` —  Const or non-const column with text to apply regular expression against. [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md).
+-   `regexp` — Const column with regular expression. [String](../data-types/string.md) or [FixedString](../data-types/fixedstring.md).
+
+**Returned values**
+
+-   If ClickHouse finds at least one matching group, returns `Array(Array(String))` column, clustered by group_id (1 to N, where N is number of capturing groups in `regexp`).
+
+-   If there is no matching group, returns empty array.
+
+Type: [Array](../data-types/array.md).
+
+**Example**
+
+Query:
+
+``` sql
+SELECT extractAllGroups('abc=123, 8="hkl"', '("[^"]+"|\\w+)=("[^"]+"|\\w+)');
+```
+
+Result:
+
+``` text
+┌─extractAllGroups('abc=123, 8="hkl"', '("[^"]+"|\\w+)=("[^"]+"|\\w+)')─┐
+│ [['abc','123'],['8','"hkl"']]                                         │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
 [Original article](https://clickhouse.tech/docs/en/query_language/functions/splitting_merging_functions/) <!--hide-->

--- a/docs/ru/sql-reference/functions/splitting-merging-functions.md
+++ b/docs/ru/sql-reference/functions/splitting-merging-functions.md
@@ -33,4 +33,42 @@ SELECT alphaTokens('abca1abc')
 └─────────────────────────┘
 ```
 
+## extractAllGroups(text, regexp) {#extractallgroups}
+
+Выделяет все группы из неперекрывающихся подстрок, которые соответствуют регулярному выражению.
+
+**Синтаксис** 
+
+``` sql
+extractAllGroups(text, regexp) 
+```
+
+**Параметры** 
+
+-   `text` — [String](../data-types/string.md) или [FixedString](../data-types/fixedstring.md).
+-   `regexp` — Регулярное выражение. Константа. [String](../data-types/string.md) или [FixedString](../data-types/fixedstring.md).
+
+**Возвращаемые значения**
+
+-   Если найдена хотя бы одна подходящая группа, функция возвращает столбец вида `Массив(Массив(Строка))`, сгруппированный по идентификатору группы (от 1 до N, где N — количество групп с захватом содержимого в `regexp`).
+
+-   Если подходящих групп не найдено, возвращает пустой массив.
+
+Тип: [Array](../data-types/array.md).
+
+**Пример использования**
+
+Запрос:
+
+``` sql
+SELECT extractAllGroups('abc=123, 8="hkl"', '("[^"]+"|\\w+)=("[^"]+"|\\w+)');
+```
+
+Результат:
+
+``` text
+┌─extractAllGroups('abc=123, 8="hkl"', '("[^"]+"|\\w+)=("[^"]+"|\\w+)')─┐
+│ [['abc','123'],['8','"hkl"']]                                         │
+└───────────────────────────────────────────────────────────────────────┘
+```
 [Оригинальная статья](https://clickhouse.tech/docs/ru/query_language/functions/splitting_merging_functions/) <!--hide-->


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- Documentation (changelog entry is not required)


Detailed description / Documentation draft
Draft: http://130.193.44.42:32772/docs/en/sql-reference/functions/splitting-merging-functions/#extractallgroups

