### PR TITLE
DOCSUP-715 network_compression_method and network_zstd_compression_level

### DIFF
--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -512,8 +512,7 @@ Default value: 0.
 
 ## network_compression_method {#network_compression_method}
 
-Sets the method of data compression when writing.
-Controls compression, that uses internally for communication between servers and for sending data to native clickhouse-client. ClickHouse uses the same compression methods as clickhouse-compressor does.
+Sets the method of data compression that is used for communication between servers and for sending data to native clickhouse-client.
 
 Possible values:
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -536,10 +536,6 @@ Possible values:
 
 Default value: `1`.
 
-**See Also**
-
--   [network_compression_method](#network_compression_method)
-
 ## log\_queries {#settings-log-queries}
 
 Setting up query logging.

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -512,23 +512,23 @@ Default value: 0.
 
 ## network_compression_method {#network_compression_method}
 
-Allows you to select the method of data compression when writing.
-Controls compression, that use internally for communication between servers and for sending data to native clickhouse-client. ClickHouse use the same compression methods as clickhouse-compressor does.
-
-
-It is LZ4 by default, but it could be adjusted with [network_compression_method](#network_compression_method) setting. Possible values are 'lz4' and 'zstd'.
+Sets the method of data compression when writing.
+Controls compression, that uses internally for communication between servers and for sending data to native clickhouse-client. ClickHouse uses the same compression methods as clickhouse-compressor does.
 
 Possible values:
 
 -   `LZ4` — sets LZ4 compression method.
--   `ZSTD` — sets ZSTD compression method. In addition, you can define [network_zstd_compression_level](#network_zstd_compression_level).
+-   `ZSTD` — sets ZSTD compression method.
 
 Default value: `LZ4`.
 
+**See Also**
+
+-   [network_zstd_compression_level](#network_zstd_compression_level)
 
 ## network_zstd_compression_level {#network_zstd_compression_level}
 
-Allows you to select the level of ZSTD compression. Used only when [network_compression_method](#network_compression_method) is set as `ZSTD`.
+Adjusts the level of ZSTD compression. Used only when [network_compression_method](#network_compression_method) is set to `ZSTD`.
 
 Possible values:
 
@@ -536,11 +536,9 @@ Possible values:
 
 Default value: `1`.
 
+**See Also**
 
-
-
-
-
+-   [network_compression_method](#network_compression_method)
 
 ## log\_queries {#settings-log-queries}
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -516,19 +516,19 @@ Allows you to select the method of data compression when writing.
 Controls compression, that use internally for communication between servers and for sending data to native clickhouse-client. ClickHouse use the same compression methods as clickhouse-compressor does.
 
 
-It is lz4 by default, but it could be adjusted with [network_compression_method](#network_zstd_compression_level) setting. Possible values are 'lz4' and 'zstd'.
+It is LZ4 by default, but it could be adjusted with [network_compression_method](#network_compression_method) setting. Possible values are 'lz4' and 'zstd'.
 
 Possible values:
 
 -   `LZ4` — sets LZ4 compression method.
--   `zstd` — sets Zstd compression method. In addition, you can define network_zstd_compression_level.
+-   `ZSTD` — sets ZSTD compression method. In addition, you can define [network_zstd_compression_level](#network_zstd_compression_level).
 
 Default value: `LZ4`.
 
 
 ## network_zstd_compression_level {#network_zstd_compression_level}
 
-Allows you to select the level of ZSTD compression. Used only when [network_compression_method](#network_compression_method) is set as zstd.
+Allows you to select the level of ZSTD compression. Used only when [network_compression_method](#network_compression_method) is set as `ZSTD`.
 
 Possible values:
 

--- a/docs/en/operations/settings/settings.md
+++ b/docs/en/operations/settings/settings.md
@@ -510,6 +510,38 @@ Possible values:
 
 Default value: 0.
 
+## network_compression_method {#network_compression_method}
+
+Allows you to select the method of data compression when writing.
+Controls compression, that use internally for communication between servers and for sending data to native clickhouse-client. ClickHouse use the same compression methods as clickhouse-compressor does.
+
+
+It is lz4 by default, but it could be adjusted with [network_compression_method](#network_zstd_compression_level) setting. Possible values are 'lz4' and 'zstd'.
+
+Possible values:
+
+-   `LZ4` — sets LZ4 compression method.
+-   `zstd` — sets Zstd compression method. In addition, you can define network_zstd_compression_level.
+
+Default value: `LZ4`.
+
+
+## network_zstd_compression_level {#network_zstd_compression_level}
+
+Allows you to select the level of ZSTD compression. Used only when [network_compression_method](#network_compression_method) is set as zstd.
+
+Possible values:
+
+-   Positive integer from 1 to 15.
+
+Default value: `1`.
+
+
+
+
+
+
+
 ## log\_queries {#settings-log-queries}
 
 Setting up query logging.

--- a/docs/ru/operations/settings/settings.md
+++ b/docs/ru/operations/settings/settings.md
@@ -515,6 +515,31 @@ ClickHouse использует этот параметр при чтении д
 
 Значение по умолчанию: 0.
 
+## network_compression_method {#network_compression_method}
+
+Задает метод сжатия данных, используемый для связи между серверами и отправки данных в собственный clickhouse-клиент.
+
+Возможные значения:
+
+-   `LZ4` — устанавливает метод сжатия LZ4.
+-   `ZSTD` — устанавливает метод сжатия ZSTD.
+
+Значение по умолчанию: `LZ4`.
+
+См. также:
+
+-   [network_zstd_compression_level](#network_zstd_compression_level)
+
+## network_zstd_compression_level {#network_zstd_compression_level}
+
+Регулирует уровень сжатия ZSTD. Используется только тогда, когда [network_compression_method](#network_compression_method) имеет значение `ZSTD`.
+
+Возможные значения:
+
+-   Положительное целое число от 1 до 15.
+
+Значение по умолчанию: `1`.
+
 ## log\_queries {#settings-log-queries}
 
 Установка логирования запроса.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):

* Documentation (changelog entry is not required)

Detailed description / Documentation draft

Add description for following settings: 
* `network_compression_method`
* `network_zstd_compression_level`

Draft: http://130.193.44.42:32778/docs/en/operations/settings/settings/#network_compression_method






